### PR TITLE
enable lower case kerberos principal

### DIFF
--- a/conf/cepces.conf.dist
+++ b/conf/cepces.conf.dist
@@ -68,6 +68,7 @@ ccache=True
 #
 # Default: <empty list>
 principals=
+  ${shortname}$$
   ${SHORTNAME}$$
   host/${SHORTNAME}
   host/${fqdn}


### PR DESCRIPTION
AD integration products such as Centrify create lower-cased "Computer Accounts"
in Active Directory.